### PR TITLE
fix: remove useless links

### DIFF
--- a/web-app/django/VIM/templates/main/about.html
+++ b/web-app/django/VIM/templates/main/about.html
@@ -36,10 +36,6 @@
                 <a href="https://linkedmusic.ca/omid/">A list of online databases</a>
                 either about musical instruments or with musical instrument sections.
               </li>
-              <li>
-                <a href="https://linkedmusic.ca/pdfs/VIM%20Potential%20Templates.pdf">Potential UMIL Website Templates</a>
-                (based on photography, museum and shopping websites).
-              </li>
             </ul>
           </p>
         </div>
@@ -62,10 +58,6 @@
               <li>
                 <a href="https://linkedmusic.ca/omid/">Une liste de bases de données en ligne</a>
                 concernant les instruments de musique ou contenant des sections sur les instruments de musique.
-              </li>
-              <li>
-                <a href="https://linkedmusic.ca/pdfs/VIM%20Potential%20Templates.pdf">Des modèles potentiels de sites Web UMIL</a>
-                (basés sur des sites de photographie, de musées et de vente en ligne).
               </li>
             </ul>
           </p>


### PR DESCRIPTION
Remove the site template link, but keep the other links.

Resolves: #168