### PR TITLE
feat: add stats number to home page

### DIFF
--- a/web-app/django/VIM/apps/main/views.py
+++ b/web-app/django/VIM/apps/main/views.py
@@ -1,11 +1,24 @@
 from django.contrib.auth import login
+from django.contrib.auth.models import User
 from django.shortcuts import render
 from django.shortcuts import redirect
 from django.contrib.auth.forms import UserCreationForm
+from VIM.apps.instruments.models import Instrument, Language
 
 
 def home(request):
-    return render(request, "main/index.html", {"active_tab": "home"})
+    # Fetch statistics from database
+    total_instruments = Instrument.objects.count()
+    total_languages = Language.objects.count()
+    total_editors = User.objects.count()
+
+    context = {
+        "active_tab": "home",
+        "total_instruments": total_instruments,
+        "total_languages": total_languages,
+        "total_editors": total_editors,
+    }
+    return render(request, "main/index.html", context)
 
 
 def about(request):

--- a/web-app/django/VIM/templates/main/index.html
+++ b/web-app/django/VIM/templates/main/index.html
@@ -1,55 +1,99 @@
 {% extends "base.html" %}
 
 {% load static %}
+{% load django_vite %}
 
 {% block title %}
   UMIL
 {% endblock title %}
+
+{% block ts_files %}
+  {% vite_asset 'src/StatsAnimation.ts' %}
+{% endblock ts_files %}
 
 {% block css_files %}
   <link rel="stylesheet" href="{% static 'assets/css/main/index.css' %}" />
 {% endblock css_files %}
 
 {% block content %}
-  <div class="container content-container d-flex align-items-center justify-content-center min-vh-80 position-relative">
-    <div class="z-2">
-      <!-- Desktop Layout -->
-      <div class="d-none d-md-block">
-        <div class="row">
-          <div class="col-6">
+  <div class="container content-container d-flex flex-column justify-content-center min-vh-90 position-relative">
+    <div class="z-2 d-flex align-items-center min-vh-70">
+      <div class="w-100">
+        <!-- Desktop Layout -->
+        <div class="d-none d-md-block">
+          <div class="row">
+            <div class="col-6">
+              <h1>
+                <span style="color: #876445;">Universal</span> Musical Instrument Lexicon
+              </h1>
+            </div>
+            <div class="col-6 notranslate">
+              <h1>
+                Lexique <span style="color: #876445;">Universel</span> des Instruments de Musique
+              </h1>
+            </div>
+          </div>
+          <div class="row">
+            <div class="col-6">
+              <p>
+                Where the past and present of music collide.
+                <br />
+                Explore, share, connect musical instruments in every language.
+              </p>
+            </div>
+            <div class="col-6 notranslate">
+              <p>
+                Où le passé et le présent de la musique se rencontrent. Explorez, partagez, connectez des instruments de musique dans toutes les langues.
+              </p>
+            </div>
+          </div>
+          <div class="row">
+            <div class="col-6">
+              <a href="{% url "instrument-list" %}?language=English">
+                <button class="btn btn-warning rounded-pill start-btn">
+                  Visit English Site
+                </button>
+              </a>
+            </div>
+            <div class="col-6 notranslate">
+              <a href="{% url "instrument-list" %}?language=French">
+                <button class="btn btn-warning rounded-pill start-btn">
+                  Visitez le site en francais
+                </button>
+              </a>
+            </div>
+          </div>
+        </div>
+        <!-- Mobile Layout -->
+        <div class="d-md-none my-5 px-2">
+          <p class="notranslate">
+            <em>La version française suit.</em>
+          </p>
+          <!-- English Content -->
+          <div class="mb-5">
             <h1>
               <span style="color: #876445;">Universal</span> Musical Instrument Lexicon
             </h1>
-          </div>
-          <div class="col-6 notranslate">
-            <h1>
-              Lexique <span style="color: #876445;">Universel</span> des Instruments de Musique
-            </h1>
-          </div>
-        </div>
-        <div class="row">
-          <div class="col-6">
             <p>
               Where the past and present of music collide.
               <br />
               Explore, share, connect musical instruments in every language.
             </p>
-          </div>
-          <div class="col-6 notranslate">
-            <p>
-              Où le passé et le présent de la musique se rencontrent. Explorez, partagez, connectez des instruments de musique dans toutes les langues.
-            </p>
-          </div>
-        </div>
-        <div class="row">
-          <div class="col-6">
             <a href="{% url "instrument-list" %}?language=English">
               <button class="btn btn-warning rounded-pill start-btn">
                 Visit English Site
               </button>
             </a>
           </div>
-          <div class="col-6 notranslate">
+          <hr class="my-4" style="border-color: #876445; border-width: 2px;" />
+          <!-- French Content -->
+          <div class="mt-5 notranslate">
+            <h1>
+              Lexique <span style="color: #876445;">Universel</span> des Instruments de Musique
+            </h1>
+            <p>
+              Où le passé et le présent de la musique se rencontrent. Explorez, partagez, connectez des instruments de musique dans toutes les langues.
+            </p>
             <a href="{% url "instrument-list" %}?language=French">
               <button class="btn btn-warning rounded-pill start-btn">
                 Visitez le site en francais
@@ -58,41 +102,31 @@
           </div>
         </div>
       </div>
-      <!-- Mobile Layout -->
-      <div class="d-md-none my-5 px-2">
-        <p class="notranslate">
-          <em>La version française suit.</em>
-        </p>
-        <!-- English Content -->
-        <div class="mb-5">
-          <h1>
-            <span style="color: #876445;">Universal</span> Musical Instrument Lexicon
-          </h1>
-          <p>
-            Where the past and present of music collide.
-            <br />
-            Explore, share, connect musical instruments in every language.
-          </p>
-          <a href="{% url "instrument-list" %}?language=English">
-            <button class="btn btn-warning rounded-pill start-btn">
-              Visit English Site
-            </button>
-          </a>
+    </div>
+    <!-- Statistics Section -->
+    <div class="stats-section z-2 mb-4 bg-secondary bg-opacity-25 border border-secondary py-2 mx-2">
+      <div class="row text-center justify-content-center justify-content-md-between align-items-center">
+        <div class="col-8 col-md-3 mb-3 mb-md-0">
+          <div class="stat-item">
+            <h3 class="stat-number text-warning mb-1">
+              {{ total_instruments|default:"859" }}
+            </h3>
+            <p class="fs-6 mb-0">Instruments</p>
+          </div>
         </div>
-        <hr class="my-4" style="border-color: #876445; border-width: 2px;" />
-        <!-- French Content -->
-        <div class="mt-5 notranslate">
-          <h1>
-            Lexique <span style="color: #876445;">Universel</span> des Instruments de Musique
-          </h1>
-          <p>
-            Où le passé et le présent de la musique se rencontrent. Explorez, partagez, connectez des instruments de musique dans toutes les langues.
-          </p>
-          <a href="{% url "instrument-list" %}?language=French">
-            <button class="btn btn-warning rounded-pill start-btn">
-              Visitez le site en francais
-            </button>
-          </a>
+        <div class="col-8 col-md-3 mb-3 mb-md-0">
+          <div class="stat-item">
+            <h3 class="stat-number text-warning mb-1">
+              {{ total_languages|default:"623" }}
+            </h3>
+            <p class="fs-6 mb-0">Languages</p>
+          </div>
+        </div>
+        <div class="col-8 col-md-3 mb-3 mb-md-0">
+          <div class="stat-item">
+            <h3 class="stat-number text-warning mb-1">{{ total_editors|default:"2" }}</h3>
+            <p class="fs-6 mb-0">Editors</p>
+          </div>
         </div>
       </div>
     </div>

--- a/web-app/frontend/assets/scss/_bootstrap-overrides.scss
+++ b/web-app/frontend/assets/scss/_bootstrap-overrides.scss
@@ -3,7 +3,7 @@
 
 // Bootstrap variable overrides (MUST come before importing Bootstrap)
 $primary: $umil-green-primary;
-$secondary: $umil-green-dark;
+$secondary: $umil-green-light;
 $dark: $umil-green-dark;
 $light: $umil-cream;
 
@@ -47,7 +47,9 @@ $utilities: map-merge(
       class: min-vh,
       values: (
         100: 100vh,
+        90: 90vh,
         80: 80vh,
+        70: 70vh,
         60: 60vh,
         10: 10vh,
       ),

--- a/web-app/frontend/src/StatsAnimation.ts
+++ b/web-app/frontend/src/StatsAnimation.ts
@@ -1,0 +1,90 @@
+// Stats Animation for UMIL Homepage
+class StatsAnimation {
+  private observer: IntersectionObserver;
+  private hasAnimated: boolean = false;
+
+  constructor() {
+    this.observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting && !this.hasAnimated) {
+            this.animateStats();
+            this.hasAnimated = true;
+          }
+        });
+      },
+      {
+        threshold: 0.5, // Trigger when 50% of the stats section is visible
+      },
+    );
+
+    this.init();
+  }
+
+  private init(): void {
+    // Wait for DOM to be ready
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', () => this.setupObserver());
+    } else {
+      this.setupObserver();
+    }
+  }
+
+  private setupObserver(): void {
+    const statsSection = document.querySelector('.stats-section');
+    if (statsSection) {
+      this.observer.observe(statsSection);
+    }
+  }
+
+  private animateStats(): void {
+    const statNumbers = document.querySelectorAll('.stat-number');
+
+    statNumbers.forEach((element) => {
+      const htmlElement = element as HTMLElement;
+      const targetText = htmlElement.textContent?.replace(/,/g, '') || '0';
+      const targetValue = parseInt(targetText, 10);
+
+      if (isNaN(targetValue)) return;
+
+      this.animateNumber(htmlElement, 0, targetValue, 1000); // 1 second animation
+    });
+  }
+
+  private animateNumber(
+    element: HTMLElement,
+    start: number,
+    end: number,
+    duration: number,
+  ): void {
+    const startTime = performance.now();
+
+    const updateNumber = (currentTime: number) => {
+      const elapsed = currentTime - startTime;
+      const progress = Math.min(elapsed / duration, 1);
+
+      // Use easeOutCubic for smooth animation
+      const easeProgress = 1 - Math.pow(1 - progress, 3);
+      const currentValue = Math.floor(start + (end - start) * easeProgress);
+
+      // Format number with commas
+      element.textContent = this.formatNumberWithCommas(currentValue);
+
+      if (progress < 1) {
+        requestAnimationFrame(updateNumber);
+      } else {
+        // Ensure final value is exactly the target
+        element.textContent = this.formatNumberWithCommas(end);
+      }
+    };
+
+    requestAnimationFrame(updateNumber);
+  }
+
+  private formatNumberWithCommas(num: number): string {
+    return num.toLocaleString();
+  }
+}
+
+// Initialize the animation when this module is loaded
+new StatsAnimation();

--- a/web-app/frontend/vite.config.js
+++ b/web-app/frontend/vite.config.js
@@ -26,6 +26,7 @@ export default defineConfig({
           'src/instruments/DisplaySettings.ts',
         ),
         languageList: resolve(__dirname, 'src/LanguageList.ts'),
+        statsAnimation: resolve(__dirname, 'src/StatsAnimation.ts'),
       },
       output: {
         entryFileNames: '[name].js',


### PR DESCRIPTION
refs: #185

Although the issue specifies the About page, I think these numbers look better on the Home page, as it aligns with the convention of a hero section. This is the initial PR to add only the stats numbers; I will include the remaining charts in a separate PR.

Preview:
<img width="1472" height="927" alt="image" src="https://github.com/user-attachments/assets/ddebb3a8-2cdf-41b4-986c-80afdfad7757" />
