### PR TITLE
style: set min height for content container

### DIFF
--- a/web-app/django/VIM/templates/instruments/index.html
+++ b/web-app/django/VIM/templates/instruments/index.html
@@ -80,7 +80,7 @@
         </div>
       </div>
       <div class="col-xl-9">
-        <div class="bg-white pt-3 container-border">
+        <div class="bg-white pt-3 container-border min-vh-70 position-relative">
           <div class="navigation d-flex justify-content-between align-items-center">
             <div class="d-flex">
               <h4 class="ms-3 me-2 my-auto">
@@ -152,7 +152,7 @@
             {% include "instruments/includes/stdView.html" %}
 
           </div>
-          <div class="mb-3 d-flex flex-md-row flex-column align-items-center justify-content-center">
+          <div class="mb-3 d-flex flex-md-row flex-column align-items-center justify-content-center position-absolute bottom-0 start-0 end-0">
             {% include "instruments/includes/paginationOptions.html" %}
 
           </div>


### PR DESCRIPTION
refs: #352

before:
<img width="1503" height="920" alt="image" src="https://github.com/user-attachments/assets/a45f6948-2a20-4705-b4a2-598bd77d21a7" />

after:
<img width="1504" height="919" alt="image" src="https://github.com/user-attachments/assets/5456b0d1-c006-4c7f-9480-17a7e871d826" />
