### PR TITLE
Typo fix: change folder name for production server

### DIFF
--- a/.github/workflows/cd_prod.yml
+++ b/.github/workflows/cd_prod.yml
@@ -19,27 +19,27 @@ jobs:
       - name: Stop the current Docker containers running
         run: |
           ssh -J ${{ secrets.PROXY_USERNAME }}@${{ secrets.PROXY_HOST1 }},${{ secrets.PROXY_USERNAME }}@${{ secrets.PROXY_HOST_PROD }} ${{ secrets.USERNAME }}@${{ secrets.HOST_PROD }} \
-            "cd /virtual_instrument_museum &&
+            "cd /virtual-instrument-museum &&
              sudo docker compose stop"
       - name: Fetch new updates from remote `origin` and log current branches
         run: |
           ssh -J ${{ secrets.PROXY_USERNAME }}@${{ secrets.PROXY_HOST1 }},${{ secrets.PROXY_USERNAME }}@${{ secrets.PROXY_HOST_PROD }} ${{ secrets.USERNAME }}@${{ secrets.HOST_PROD }} \
-            "cd /virtual_instrument_museum &&
+            "cd /virtual-instrument-museum &&
              sudo git fetch origin -v &&
              sudo git branch -v"
       - name: Checkout to `main` branch and pull new changes 
         run: |
           ssh -J ${{ secrets.PROXY_USERNAME }}@${{ secrets.PROXY_HOST1 }},${{ secrets.PROXY_USERNAME }}@${{ secrets.PROXY_HOST_PROD }} ${{ secrets.USERNAME }}@${{ secrets.HOST_PROD }} \
-            "cd /virtual_instrument_museum &&
+            "cd /virtual-instrument-museum &&
              sudo git checkout main &&
              sudo git pull origin main"
       - name: Build docker images
         run: |
           ssh -J ${{ secrets.PROXY_USERNAME }}@${{ secrets.PROXY_HOST1 }},${{ secrets.PROXY_USERNAME }}@${{ secrets.PROXY_HOST_PROD }} ${{ secrets.USERNAME }}@${{ secrets.HOST_PROD }} \
-            "cd /virtual_instrument_museum &&
+            "cd /virtual-instrument-museum &&
              sudo docker compose build --no-cache"
       - name: Start the services
         run: |
           ssh -J ${{ secrets.PROXY_USERNAME }}@${{ secrets.PROXY_HOST1 }},${{ secrets.PROXY_USERNAME }}@${{ secrets.PROXY_HOST_PROD }} ${{ secrets.USERNAME }}@${{ secrets.HOST_PROD }} \
-            "cd /virtual_instrument_museum &&
+            "cd /virtual-instrument-museum &&
              sudo docker compose up -d"


### PR DESCRIPTION
On production server, the app is in `virtual-instrument-museum` instead of `virtual_instrument_museum` (hyphen instead of underscore)