### PR TITLE
fix: instrument navbar style

### DIFF
--- a/web-app/django/VIM/apps/instruments/views/instrument_detail.py
+++ b/web-app/django/VIM/apps/instruments/views/instrument_detail.py
@@ -59,4 +59,6 @@ class InstrumentDetail(DetailView):
         # Get all languages for the dropdown
         context["languages"] = Language.objects.all()
 
+        context["active_tab"] = "instruments"
+
         return context

--- a/web-app/frontend/assets/scss/instruments/index.scss
+++ b/web-app/frontend/assets/scss/instruments/index.scss
@@ -24,10 +24,6 @@ h4 {
   color: $umil-green-primary;
 }
 
-.active {
-  font-weight: bold;
-}
-
 .toggle-more {
   color: #0b0f07;
 }


### PR DESCRIPTION
- Set the active tab to "instruments" for instrument detail page
- Removed active style to unify active navtab style

refs: #391